### PR TITLE
add Dockerfile to build package tooling image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,8 @@
 !go.sum
 !go.mod
 
+!Dockerfile
+
 !*.yaml
+
+!*.sh

--- a/package-tooling-image/Dockerfile
+++ b/package-tooling-image/Dockerfile
@@ -1,0 +1,29 @@
+FROM bitnami/golang:1.17
+
+ENV DOCKER_CE_VERSION 5:20.10.14~3-0~debian-bullseye
+ENV DOCKER_CE_CLI_VERSION 5:20.10.14~3-0~debian-bullseye
+ENV CONTAINERD_VERSION 1.5.11-1
+ENV GOVERSION 1.17.7
+
+RUN apt-get update && \
+    apt-get install -y make gnupg lsb-release
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update && \
+    apt-get install -y \
+        docker-ce=${DOCKER_CE_VERSION} \
+        docker-ce-cli=${DOCKER_CE_CLI_VERSION} \
+        containerd.io=${CONTAINERD_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://get.docker.com/ | sh
+
+RUN go install github.com/vmware-tanzu/build-tooling-for-integrations.gitpackage-tools@main
+
+COPY build-packages.sh /build-packages.sh
+ENTRYPOINT ["/build-packages.sh"]

--- a/package-tooling-image/build-packages.sh
+++ b/package-tooling-image/build-packages.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ ! -z "${REGISTRY_USERNAME:-}" ] && [ ! -z "${REGISTRY_PASSWORD:-}" ] && [ ! -z "${REGISTRY_SERVER:-}" ]; then
+   docker login --username "${REGISTRY_USERNAME}" --password "${REGISTRY_PASSWORD}" "${REGISTRY_SERVER}"
+fi
+
+# Start a local docker registry
+echo "Stopping and removing any existing local docker registry..."
+docker container stop registry && docker container rm -v registry || true
+echo "Starting local docker registry..."
+docker run -d -p 5001:5000 --name registry mirror.gcr.io/library/registry:2
+
+cd /workspace
+
+# Install needed Carvel binaries for building packages
+echo "Downloading carvel binaries..."
+package-tools prepare
+
+if [[ "${OPERATIONS}" == *"kbld_replace"* ]]; then
+  package-tools kbld-replace \
+  "${DEFAULT_IMAGE}" "${NEW_IMAGE}" \
+  --kbld-config-file="${KBLD_CONFIG_FILE_PATH}";
+fi
+
+if [[ "${OPERATIONS}" == *"package_bundle_generate"* ]]; then
+  package-tools package-bundle generate "${PACKAGE_NAME}" \
+  --thick="${THICK}" \
+  --version="${PACKAGE_VERSION}" \
+  --sub-version="${PACKAGE_SUB_VERSION}" \
+  --registry="${OCI_REGISTRY}" \
+  --local-registry-url="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry):5000";
+fi
+
+if [[ "${OPERATIONS}" == *"package_bundle_all_generate"* ]]; then
+  package-tools package-bundle generate \
+  --all \
+  --thick="${THICK}" \
+  --version="${PACKAGE_VERSION}" \
+  --sub-version="${PACKAGE_SUB_VERSION}" \
+  --repository="${PACKAGE_REPOSITORY}" \
+  --registry="${OCI_REGISTRY}" \
+  --local-registry-url="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry):5000";
+fi
+
+if [[ "${OPERATIONS}" == *"package_bundle_push"* ]]; then
+  package-tools package-bundle push "${PACKAGE_NAME}" \
+  --version="${PACKAGE_VERSION}" \
+  --sub-version=${PACKAGE_SUB_VERSION} \
+  --registry="${OCI_REGISTRY}";
+fi
+
+if [[ "${OPERATIONS}" == *"package_bundle_all_push"* ]]; then
+  package-tools package-bundle push \
+  --all \
+  --repository="${PACKAGE_REPOSITORY}" \
+  --version="${PACKAGE_VERSION}" \
+  --sub-version=${PACKAGE_SUB_VERSION} \
+  --registry="${OCI_REGISTRY}";
+fi
+
+if [[ "${OPERATIONS}" == *"repo_bundle_generate"* ]]; then
+  package-tools repo-bundle generate \
+  --repository="${PACKAGE_REPOSITORY}" \
+  --version="${REPO_BUNDLE_VERSION}" \
+  --sub-version="${REPO_BUNDLE_SUB_VERSION}" \
+  --registry="${OCI_REGISTRY}" \
+  --package-values-file="${PACKAGE_VALUES_FILE}" \
+  --local-registry-url="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry):5000";
+fi
+
+if [[ "${OPERATIONS}" == *"repo_bundle_push"* ]]; then
+  package-tools repo-bundle push \
+  --repository="${PACKAGE_REPOSITORY}" \
+  --version="${REPO_BUNDLE_VERSION}" \
+  --sub-version="${REPO_BUNDLE_SUB_VERSION}" \
+  --registry="${OCI_REGISTRY}";
+fi
+
+if [[ "${OPERATIONS}" == *"vendir_sync"* ]]; then
+  package-tools vendir sync;
+fi


### PR DESCRIPTION
This PR adds Dockerfile and other needed files to build package tooling image. The image that's built with this Dockerfile can be used to build package and repo bundles.

This PR should be merged after this https://github.com/vmware-tanzu/build-tooling-for-integrations/pull/2

Testing:
1. Build the package tooling image
2. Run the container by specifying env vars needed to build package and repo bundles.