### PR TITLE
add build tooling templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !go.mod
 
 !Dockerfile
+!Makefile
 
 !*.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM bash
+COPY ./templates/Dockerfile /
+COPY ./templates/.golangci.yaml /

--- a/templates/.golangci.yaml
+++ b/templates/.golangci.yaml
@@ -1,0 +1,163 @@
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goheader:
+    values:
+      const:
+       COMPANY: VMware, Inc.
+       LICENSE: Apache-2.0
+      regexp:
+       YEAR: 20\d*-*\d*
+    template: |-
+      Copyright {{ YEAR }} {{ COMPANY }} All Rights Reserved.
+      SPDX-License-Identifier: {{ LICENSE }}
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/vmware-tanzu
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/aunum/log").Infof
+          - (github.com/aunum/log").Warnf
+          - (github.com/aunum/log").Errorf
+          - (github.com/aunum/log").Fatalf
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  whitespace:
+    multi-func: true
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - goconst
+    - gocritic
+    - gocyclo
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - exhaustive
+  # - gochecknoinits
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - lll
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - scopelint
+  # - wsl
+
+issues:
+  exclude:
+    - 'declaration of "(err|ctx)" shadows declaration at'
+    - 'unnamedResult: consider giving a name to these results'
+    - '(Expect directory permissions to be 0750 or less|Expect (WriteFile|file) permissions to be 0600 or less)'
+
+  exclude-rules:
+    - path: pinniped/internal/mocks
+      linters:
+        - goimports
+    - path: apis/run/v1alpha1
+      linters:
+        - goimports
+    - path: _test\.go
+      linters:
+        - dupl
+        - gocritic
+        - funlen
+
+    # https://github.com/go-critic/go-critic/issues/926
+    - linters:
+        - gocritic
+      text: "unnecessaryDefer:"
+
+    - path: pkg/v1/tkr/controllers/source/suite_test.go
+      linters:
+        - nolintlint
+      text: "is unused for linter staticcheck"
+
+    - linters:
+        - revive
+      text: "that stutters"
+
+    - path: zz_.*\.go
+      linters:
+        - revive
+      text: "it will be inferred from"
+
+  include:
+    - EXC0011 # disable excluding of issues about missing package comments from stylecheck
+
+  # Show all errors for all linters. Setting these to 0 disables limiting error reporting.
+  max-same-issues: 0
+  max-issues-per-linter: 0
+
+run:
+  skip-dirs:
+    - test/
+    - fakes/
+  timeout: 15m
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.38.0 # use the fixed version to not introduce new linters unexpectedly

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+#syntax=docker/dockerfile:1.4
+
+ARG BUILDER_BASE_IMAGE=golang:1.17
+
+FROM $BUILDER_BASE_IMAGE as base
+WORKDIR /workspace
+# Copy the go source
+COPY --from=component . ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Linting
+FROM golangci/golangci-lint:latest AS lint-base
+FROM base AS lint
+RUN --mount=target=.,from=component \
+    --mount=from=lint-base,src=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/.cache/golangci-lint \
+    golangci-lint run --config /workspace/.golangci.yaml --timeout 10m0s ./...
+
+# Testing
+FROM base AS test
+RUN --mount=target=.,from=component \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go test ./...
+
+# Build the manager binary
+FROM base as builder
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN --mount=target=.,from=component \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /out/manager ./main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /out/manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,0 +1,185 @@
+IMG_DEFAULT_TAG := latest
+IMG_VERSION_OVERRIDE ?= $(IMG_DEFAULT_TAG)
+COMPONENTS ?= ""?""?""
+
+.PHONY: init
+init: ## Fetch the Dockerfile and pull image needed to build packages
+	docker run --rm -v ${PWD}:/workspace --entrypoint /bin/sh quay.io/hyayiv/build-tooling:latest -c "cp Dockerfile /workspace && cp .golangci.yaml /workspace"
+    docker pull quay.io/hyayiv/packaging:latest
+
+.PHONY: all
+all: docker-all package-vendir-sync package-bundle-generate-all package-bundle-push-all ## Run linter, tests, build and publish images and packages
+
+.PHONY: docker-all
+docker-all: $(COMPONENTS) ## Run linter, tests, build and publish images
+
+.PHONY: $(COMPONENTS)
+$(COMPONENTS):
+	$(eval COMPONENT = $(word 1,$(subst ?, ,$@)))
+	$(eval IMAGE_NAME = $(word 2,$(subst ?, ,$@)))
+	$(eval PACKAGE_PATH = $(word 3,$(subst ?, ,$@)))
+	$(eval IMAGE = $(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
+ifneq ($(strip $(OCI_REGISTRY)),)
+	$(eval IMAGE = $(OCI_REGISTRY)/$(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
+endif
+	$(eval KBLD_CONFIG_FILE_PATH = packages/$(PACKAGE_PATH)/kbld-config.yaml)
+	$(eval DEFAULT_IMAGE = $(IMAGE_NAME):$(IMG_DEFAULT_TAG))
+	make COMPONENT=$(COMPONENT) lint
+	make COMPONENT=$(COMPONENT) test
+	make IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
+	make IMAGE=$(IMAGE) docker-publish
+	make KBLD_CONFIG_FILE_PATH=$(KBLD_CONFIG_FILE_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
+
+.PHONY: docker-build
+docker-build: ## Build docker image
+ifneq ($(strip $(COMPONENT)),)
+	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-context component=$(COMPONENT) --load .
+else
+	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-context component=. --load .
+endif
+
+.PHONY: docker-publish
+docker-publish: ## Publish docker image
+	docker push $(IMAGE)
+
+.PHONY: lint
+lint: ## Run linting
+ifneq ($(strip $(COMPONENT)),)
+	cp .golangci.yaml $(COMPONENT)
+	docker build . -f Dockerfile --target lint --build-context component=$(COMPONENT)
+	rm -rf $(COMPONENT)/.golangci.yaml
+else
+	docker build . -f Dockerfile --target lint --build-context component=.
+endif
+
+.PHONY: fmt
+fmt: ## Run go fmt against code
+ifneq ($(strip $(COMPONENT)),)
+	cd $(COMPONENT) && go fmt ./...
+else
+	go fmt ./...
+endif
+
+.PHONY: vet
+vet: ## Perform static analysis of code
+ifneq ($(strip $(COMPONENT)),)
+	cd $(COMPONENT) && go vet ./...
+else
+	go vet ./...
+endif
+
+.PHONY: test
+test: fmt vet ## Run tests
+ifneq ($(strip $(COMPONENT)),)
+	docker build . -f Dockerfile --target test --build-context component=$(COMPONENT)
+else
+	docker build . -f Dockerfile --target test --build-context component=.
+endif
+
+.PHONY: kbld-image-replace
+kbld-image-replace: ## Add newImage in kbld-config.yaml
+	@docker run \
+	  -e OPERATIONS=kbld_replace \
+	  -e KBLD_CONFIG_FILE_PATH=$(KBLD_CONFIG_FILE_PATH) \
+	  -e DEFAULT_IMAGE=$(DEFAULT_IMAGE) \
+	  -e NEW_IMAGE=$(IMAGE) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+
+.PHONY: package-bundle-generate
+package-bundle-generate: ## Generate package bundle for a particular package
+	@docker run \
+	  -e OPERATIONS=package_bundle_generate \
+	  -e PACKAGE_NAME=$(PACKAGE_NAME) \
+	  -e THICK=true \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e PACKAGE_VERSION=$(PACKAGE_VERSION) \
+	  -e PACKAGE_SUB_VERSION=$(PACKAGE_SUB_VERSION) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: package-bundle-generate-all
+package-bundle-generate-all: ## Generate package bundle for all packages
+	@docker run \
+	  -e OPERATIONS=package_bundle_all_generate \
+	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
+	  -e THICK=true \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e PACKAGE_VERSION=$(PACKAGE_VERSION) \
+	  -e PACKAGE_SUB_VERSION=$(PACKAGE_SUB_VERSION) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: package-bundle-push
+package-bundle-push: ## Push a particular package bundle
+	@docker run \
+	  -e OPERATIONS=package_bundle_push \
+	  -e PACKAGE_NAME=$(PACKAGE_NAME) \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e PACKAGE_VERSION=$(PACKAGE_VERSION) \
+	  -e PACKAGE_SUB_VERSION=$(PACKAGE_SUB_VERSION) \
+	  -e REGISTRY_USERNAME=$(REGISTRY_USERNAME) \
+	  -e REGISTRY_PASSWORD=$(REGISTRY_PASSWORD) \
+	  -e REGISTRY_SERVER=$(REGISTRY_SERVER) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: package-bundle-push-all
+package-bundle-push-all: ## Push all package bundles
+	@docker run \
+	  -e OPERATIONS=package_bundle_all_push \
+	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e PACKAGE_VERSION=$(PACKAGE_VERSION) \
+	  -e PACKAGE_SUB_VERSION=$(PACKAGE_SUB_VERSION) \
+	  -e REGISTRY_USERNAME=$(REGISTRY_USERNAME) \
+	  -e REGISTRY_PASSWORD=$(REGISTRY_PASSWORD) \
+	  -e REGISTRY_SERVER=$(REGISTRY_SERVER) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: repo-bundle-generate
+repo-bundle-generate: ## Generate repo bundle
+	@docker run \
+	  -e OPERATIONS=repo_bundle_generate \
+	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e REPO_BUNDLE_VERSION=$(REPO_BUNDLE_VERSION) \
+	  -e REPO_BUNDLE_SUB_VERSION=$(REPO_BUNDLE_SUB_VERSION) \
+	  -e PACKAGE_VALUES_FILE=$(PACKAGE_VALUES_FILE) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: repo-bundle-push
+repo-bundle-push: ## Push repo bundle
+	@docker run \
+	  -e OPERATIONS=repo_bundle_push \
+	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
+	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
+	  -e REPO_BUNDLE_VERSION=$(REPO_BUNDLE_VERSION) \
+	  -e REPO_BUNDLE_SUB_VERSION=$(REPO_BUNDLE_SUB_VERSION) \
+	  -e REGISTRY_USERNAME=$(REGISTRY_USERNAME) \
+	  -e REGISTRY_PASSWORD=$(REGISTRY_PASSWORD) \
+	  -e REGISTRY_SERVER=$(REGISTRY_SERVER) \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: package-vendir-sync
+package-vendir-sync: ## Performs vendir sync on each package
+	@docker run \
+	  -e OPERATIONS=vendir_sync \
+	  -v /var/run/docker.sock:/var/run/docker.sock \
+	  -v $(PWD):/workspace \
+		quay.io/hyayiv/packaging:latest
+
+.PHONY: help
+help: ## Show help
+	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR adds build tooling templates for integrators to use to get started with building integration for Tanzu. Templates include a Dockerfile, Makefile and .golanci.yaml.
This PR also adds a Dockerfile that puts the above mentioned template files in an image to be consumed by the integrators later
