### PR TITLE
Add documentation for build tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !Dockerfile
 !Makefile
 
+!*.md
 !*.yaml
 
 !*.sh

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 Tanzu is highly extensible by design. This extensibility allows developers to add new capabilities to their management
 or workload clusters, or introduce new types of interactions with the cluster.
 
-This project enables developers to start building and packaging new Tanzu integrations&mdash;including cluster packages and
-custom CLI commands&mdash;without prior Tanzu experience. It does so by curating and maintaining a build environment that
-produces consistent artifacts according to Tanzu’s specifications and recommendations. It allows developers to focus on
-what value they are trying to add to the cluster, rather than the tooling and processes required to make it available
-in Tanzu. A portable and validated build environment, and familiar-feeling Make targets are
+This project enables developers to start building and packaging new Tanzu integrations&mdash;including cluster packages 
+and custom CLI commands&mdash;without prior Tanzu experience. It does so by curating and maintaining a build environment
+that produces consistent artifacts according to Tanzu’s specifications and recommendations. It allows developers to 
+focus on what value they are trying to add to the cluster, rather than the tooling and processes required to make it 
+available in Tanzu. A portable and validated build environment, and familiar-feeling Make targets are
 provided by this project to do all the heavy lifting.
 
 Refer to the following table to help decide if Build Tooling is right for you:
@@ -24,7 +24,7 @@ Refer to the following table to help decide if Build Tooling is right for you:
 | ...retire early                                                   | :x:                       |
 
 
-## Quick Start
+## Try it out
 
 ### Prerequisites
 
@@ -33,12 +33,17 @@ Refer to the following table to help decide if Build Tooling is right for you:
 
 ### Build & Run
 
-1. Copy the [`Makefile`](./templates/Makefile) into your project directory
-2. Run `make init`
-3. Write your code
-4. Use the built in make targets for building, testing, and packaging your Tanzu integration
+The [Getting Started documentation](docs/build-tooling-getting-started.md) provides a getting started guide and 
+information about building tooling.
 
-## Documentation
+## Project Structure
+
+templates - contains templates such as Dockerfile, Makefile to get started with build tooling.
+
+package-tools - contains a go module that can be used to build package and repo bundles.
+
+package-tooling-image - contains Dockerfile and other needed files to build package tooling image to use package tooling
+in a containerized environment.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Build tooling related documentation
+
+Documentation related to build tooling
+
+## Table of Contents
+
+* [Build tooling getting started guide](build-tooling-getting-started.md)
+* [Add package to a package repository](add-package.md)

--- a/docs/add-package.md
+++ b/docs/add-package.md
@@ -1,0 +1,99 @@
+# Add a package to package repository
+
+This document provides guidance on how to add a package to a package repository and test it.
+
+## Steps to add a package to a package repository
+
+Let's take the example of adding a package to `management` package repository.
+Below are steps to illustrate how that can be done.
+
+1. Copy the `my-package` directory from `examples` directory in this repo to the packages directory in your project
+
+   The tree structure of `my-package` directory would look something like below and needs to be changed to use your
+   package name.
+
+   ```plain
+    packages/my-package
+    ├── Makefile
+    ├── README.md
+    ├── bundle
+    │   ├── config
+    │   │   ├── overlay
+    │   │   ├── upstream # This is the directory to add the package contents using ytt templates.
+    │   │   └── values.yaml # Package contents can be configured by providing data values in this file.
+    ├── vendir.yml # To fetch config files from a different data source.
+    ├── metadata.yaml # To provide high level information description about your package.
+    └── package.yaml # Update the Package CR spec to add/modify fields such as releaseNotes etc.
+   ```
+
+   The files in your package directory should be updated with the package config. Significance of each file is provided
+   in the above tree structure.
+
+   The Makefile contains `configure-package` and `reset-package` target to configure the package dynamically,
+   which is completely optional.
+
+2. Fetch config files from datasource [optional]
+
+   If you have updated the vendir.yaml to fetch the config from a different source, run
+
+   ```shell
+      make package-vendir-sync
+   ```
+
+3. Update kbld-config.yaml [optional]
+
+   If the container image in your config needs to be replaced by an image at build time, add an entry like below in the
+   kbld-config.yaml file in `packages/my-package` directory.
+
+   ```yaml
+       - image: "mycomponent:latest"
+         newImage: ""
+   ```
+4. Add package-values.yaml file to the packages directory [optional]
+
+   Package tooling uses package-values.yaml file to build package and repo bundles. If this is a new project this file
+   needs to be created under `packages` directory, else skip to step 5.
+
+   Below is a sample package-values.yaml file:
+
+   ```
+   #@data/values
+   ---
+   repositories:
+     management:
+       name: management
+       domain: tanzu.vmware.com
+       packageSpec:
+         syncPeriod: 5m
+         deploy:
+           kappWaitTimeout: 5m
+           kubeAPIQPS: 20
+           kubeAPIBurst: 30
+       packages:
+    ```
+   Example: https://github.com/vmware-tanzu/tanzu-framework/blob/main/packages/package-values.yaml
+   
+5. Update package-values.yaml to add your package details
+
+   `package-values.yaml` contains Ytt data values for all packages and package repositories.
+
+   Add an entry like below to package-values.yaml under `repositories.<packageRepository>.packages`.
+
+   ```yaml
+         #! package name
+       - name: my-package
+         #! Relative path to package bundle
+         path: packages/my-package
+         domain: tanzu.vmware.com
+         version: latest
+         #! this should be name:version(my-package:latest), will be replaced at build time
+         sha256: "my-package:latest"
+   ```
+
+6. Test the package bundle generation
+   Run `all` make target by passing all the vars needed to build the images and package bundles.
+
+   ```shell
+   make all
+   ```
+

--- a/docs/build-tooling-getting-started.md
+++ b/docs/build-tooling-getting-started.md
@@ -1,0 +1,50 @@
+# How to use build tooling
+
+The purpose of this document is to provide a getting started guide for someone who wants to use build tooling for Tanzu
+integrations.
+
+## Steps to use the build tooling
+
+1. Copy the contents of the Makefile
+   
+   This is the first step to consume the build tooling, the `templates` directory in this project's root directory
+   contains a Makefile with a bunch of make targets. These make targets are for initializing the build tooling,
+   building and publishing the images and packages etc. in a containerized environment so that the builds are
+   deterministic and reproducible in any environment.
+   
+
+2. Set COMPONENTS variable
+
+   For the build tooling to understand where your components are located, it needs the `COMPONENTS` variable to be set.
+   You can set the `COMPONENTS` variable either in the makefile or as an environment variable. We need to provide the
+   component's location, default image name and the package name of the component delimited by a `?` something like
+   below:
+
+   ```
+   COMPONENTS ?= featuregates?featuregates-controller-manager?featuregates
+   ```
+
+   Here `featuregates` is the path to the featuregates component from project's root directory, `featuregates-controller-manager`
+   is the default image name, `featuregates` is the name of the package, this should be same as the directory name that
+   holds the package definition of featuregates in `packages` directory that's in the project's root directory.
+
+   If your project has multiple go modules and you want to build images and packages for each of the go module, you can
+   do that by setting multiple components to the COMPONENTS variable. For example:
+
+   ```
+   COMPONENTS ?= featuregates?featuregates-controller-manager?featuregates capabilities?capabilities-controller-manager?capabilities
+   ```
+
+3. Run make init
+
+   To initialize the build tooling we need to run the `init` make target, this fetches the Dockerfile that is used for
+   building the image, testing the go module etc. and other templates needed by build tooling.
+   It also pulls the packaging image that is needed to build and publish package and repo bundles.
+
+   ```
+   make init
+   ```
+
+4. Create packages directory and add package definition in it
+   
+   Check this [documentation](./add-package.md) on how to add a package


### PR DESCRIPTION
This PR adds documentation to get started with build tooling. The following changes were made as part of this pr:
* Update README
* Add getting started guide for build tooling
* Add document that provides guidance on how to add a package.