### PR TITLE
Run vendir sync for packages concurrently

### DIFF
--- a/package-tools/cmd/vendir-sync.go
+++ b/package-tools/cmd/vendir-sync.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/vmware-tanzu/build-tooling-for-integrations/package-tools/constants"
 	"github.com/vmware-tanzu/build-tooling-for-integrations/package-tools/utils"
@@ -50,33 +51,43 @@ func runPackageVendirSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("couldn't read packages directory: %w", err)
 	}
 
+	var g errgroup.Group
+
+outer:
 	for _, file := range files {
-		if file.IsDir() {
-			for _, repo := range pkgRepos {
-				if packagesContains(packageValues.Repositories[repo].Packages, file.Name()) {
-					fmt.Printf("Syncing package %s\n", file.Name())
-					packagePath := filepath.Join(packagesPath, file.Name())
-					if err := syncPackage(packagePath, toolsBinDir); err != nil {
+		if !file.IsDir() {
+			continue
+		}
+		for _, repo := range pkgRepos {
+			if packagesContains(packageValues.Repositories[repo].Packages, file.Name()) {
+				packagePath := filepath.Join(packagesPath, file.Name())
+
+				// Skip if vendir.yml doesn't exist in package.
+				if _, err := os.Stat(filepath.Join(packagePath, "vendir.yml")); err != nil {
+					if os.IsNotExist(err) {
+						fmt.Printf("No vendir.yml found in package %q. Skipping vendir sync...\n", file.Name())
+						continue outer
+					} else {
 						return err
 					}
 				}
+
+				fmt.Printf("Syncing package %q\n", file.Name())
+				g.Go(func() error {
+					return syncPackage(packagePath, toolsBinDir)
+				})
 			}
 		}
 	}
-	return nil
+	return g.Wait()
 }
 
 func syncPackage(packagePath, toolsBinDir string) error {
-	err := os.Chdir(packagePath)
-	if err != nil {
-		return fmt.Errorf("couldn't change to directory %s: %w", packagePath, err)
-	}
-
-	cmd := exec.Command(filepath.Join(toolsBinDir, "vendir"), "sync") // #nosec G204
+	cmd := exec.Command(filepath.Join(toolsBinDir, "vendir"), "sync", "--chdir", packagePath) // #nosec G204
 	var errBytes bytes.Buffer
 	cmd.Stderr = &errBytes
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("couldn't vendir sync package: %s", errBytes.String())
+		return fmt.Errorf("couldn't vendir sync package %q: %s", filepath.Base(packagePath), errBytes.String())
 	}
 	return nil
 }

--- a/package-tools/go.mod
+++ b/package-tools/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/k14s/kbld v0.32.0
 	github.com/spf13/cobra v1.3.0
 	github.com/vmware-tanzu/carvel-imgpkg v0.24.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/package-tools/go.sum
+++ b/package-tools/go.sum
@@ -1102,6 +1102,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Use `errgroup` for running `vendir sync` concurrently. Also uses
`vendir`'s `--chdir` instead of `os.Chdir` to remove race.

### Testing done

```
$ go build -o package-tool ./main.go

# Run binary in tanzu-framework repo to test
$ ./package-tool vendir
Syncing package "addons-manager"
Syncing package "capabilities"
Syncing package "cliplugins"
Syncing package "core-management-plugins"
Syncing package "featuregates"
Syncing package "framework"
Syncing package "standalone-plugins"
Syncing package "tanzu-auth"
Syncing package "tkg"
Syncing package "tkg-autoscaler"
Syncing package "tkg-clusterclass"
Syncing package "tkg-clusterclass-aws"
Syncing package "tkg-clusterclass-azure"
Syncing package "tkg-clusterclass-docker"
Syncing package "tkg-clusterclass-vsphere"
No vendir.yml found in package "tkg-storageclass". Skipping vendir sync...
Syncing package "tkr-aws-machine-webhook"
Syncing package "tkr-azure-machine-webhook"
Syncing package "tkr-docker-machine-webhook"
Syncing package "tkr-service"
Syncing package "tkr-source-controller"
Syncing package "tkr-vsphere-machine-webhook"
```