### PR TITLE
add buildx as the prereq for build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Refer to the following table to help decide if Build Tooling is right for you:
 
 ### Prerequisites
 
-* A development machine with `make` and `docker` installed
-* A project directory for your Tanzu integration code
+1. A development machine with `make`, `docker` and `buildx` with version v0.8 or up installed. If you install Docker 
+   desktop, then it is not explicitly needed to install `buildx` as it is included by default.
+2. A project directory for your Tanzu integration code
 
 ### Build & Run
 


### PR DESCRIPTION
This PR expands the prerequisites section to add details about `buildx` and the version of buildx that is needed to use the build tooling


Fixes: https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/10