### PR TITLE
fix typo in the package-tools package name

### DIFF
--- a/package-tooling-image/Dockerfile
+++ b/package-tooling-image/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 RUN curl -sSL https://get.docker.com/ | sh
 
-RUN go install github.com/vmware-tanzu/build-tooling-for-integrations.gitpackage-tools@main
+RUN go install github.com/vmware-tanzu/build-tooling-for-integrations/package-tools@main
 
 COPY build-packages.sh /build-packages.sh
 ENTRYPOINT ["/build-packages.sh"]


### PR DESCRIPTION
Signed-off-by: Harish Yayi <yharish991@gmail.com>

# Description
This PR fixes the typo in the package-tools package name in the package-tooling Dockerfile

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/16

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
None
```

# How Has This Been Tested?
Built the package-tooling image and verified.

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
