### PR TITLE
Reordering the Dockerfile version to the top of Dockerfile

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,7 +1,7 @@
+#syntax=docker/dockerfile:1.4
+
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-#syntax=docker/dockerfile:1.4
 
 ARG BUILDER_BASE_IMAGE=golang:1.17
 


### PR DESCRIPTION
# Description
Moving the dockerfile version to the top of the Dockerfile. With the current state, the docker build fails as the --build-context flag is not getting recognized.

Fixes #19 

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [X] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
N/A

# How Has This Been Tested?
Tested by building the docker image using `make all` command

# Checklist:
- [X] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
