### PR TITLE
change the delimiter used in COMPONENTS variable to '.'

### DIFF
--- a/docs/build-tooling-getting-started.md
+++ b/docs/build-tooling-getting-started.md
@@ -17,11 +17,11 @@ integrations.
 
    For the build tooling to understand where your components are located, it needs the `COMPONENTS` variable to be set.
    You can set the `COMPONENTS` variable either in the makefile or as an environment variable. We need to provide the
-   component's location, default image name and the package name of the component delimited by a `?` something like
+   component's location, default image name and the package name of the component delimited by a `.` something like
    below:
 
    ```
-   COMPONENTS ?= featuregates?featuregates-controller-manager?featuregates
+   COMPONENTS ?= featuregates.featuregates-controller-manager.featuregates
    ```
 
    Here `featuregates` is the path to the featuregates component from project's root directory, `featuregates-controller-manager`
@@ -32,7 +32,7 @@ integrations.
    do that by setting multiple components to the COMPONENTS variable. For example:
 
    ```
-   COMPONENTS ?= featuregates?featuregates-controller-manager?featuregates capabilities?capabilities-controller-manager?capabilities
+   COMPONENTS ?= featuregates.featuregates-controller-manager.featuregates capabilities.capabilities-controller-manager.capabilities
    ```
 
 3. Run make init

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,6 +1,6 @@
 IMG_DEFAULT_TAG := latest
 IMG_VERSION_OVERRIDE ?= $(IMG_DEFAULT_TAG)
-COMPONENTS ?= ""?""?""
+COMPONENTS ?= ""."".""
 
 .PHONY: init
 init: ## Fetch the Dockerfile and pull image needed to build packages
@@ -15,28 +15,32 @@ docker-all: $(COMPONENTS) ## Run linter, tests, build and publish images
 
 .PHONY: $(COMPONENTS)
 $(COMPONENTS):
-	$(eval COMPONENT = $(word 1,$(subst ?, ,$@)))
-	$(eval IMAGE_NAME = $(word 2,$(subst ?, ,$@)))
-	$(eval PACKAGE_PATH = $(word 3,$(subst ?, ,$@)))
+	$(eval COMPONENT_PATH = $(word 1,$(subst ., ,$@)))
+	$(eval IMAGE_NAME = $(word 2,$(subst ., ,$@)))
+	$(eval PACKAGE_PATH = $(word 3,$(subst ., ,$@)))
 	$(eval IMAGE = $(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
+	$(eval DEFAULT_IMAGE = $(IMAGE_NAME):$(IMG_DEFAULT_TAG))
 ifneq ($(strip $(OCI_REGISTRY)),)
 	$(eval IMAGE = $(OCI_REGISTRY)/$(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
 endif
-	$(eval KBLD_CONFIG_FILE_PATH = packages/$(PACKAGE_PATH)/kbld-config.yaml)
-	$(eval DEFAULT_IMAGE = $(IMAGE_NAME):$(IMG_DEFAULT_TAG))
+	make component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
+
+.PHONY: component-all
+component-all:
+ifeq ($(COMPONENT_PATH),)
+	$(eval COMPONENT = .)
+else
+	$(eval COMPONENT = $(COMPONENT_PATH))
+endif
 	make COMPONENT=$(COMPONENT) lint
 	make COMPONENT=$(COMPONENT) test
 	make IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
 	make IMAGE=$(IMAGE) docker-publish
-	make KBLD_CONFIG_FILE_PATH=$(KBLD_CONFIG_FILE_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
+	make KBLD_CONFIG_FILE_PATH=packages/$(PACKAGE_PATH)/kbld-config.yaml DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
 
 .PHONY: docker-build
 docker-build: ## Build docker image
-ifneq ($(strip $(COMPONENT)),)
 	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-context component=$(COMPONENT) --load .
-else
-	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-context component=. --load .
-endif
 
 .PHONY: docker-publish
 docker-publish: ## Publish docker image
@@ -44,37 +48,25 @@ docker-publish: ## Publish docker image
 
 .PHONY: lint
 lint: ## Run linting
-ifneq ($(strip $(COMPONENT)),)
+ifneq ($(strip $(COMPONENT)),.)
 	cp .golangci.yaml $(COMPONENT)
 	docker build . -f Dockerfile --target lint --build-context component=$(COMPONENT)
 	rm -rf $(COMPONENT)/.golangci.yaml
 else
-	docker build . -f Dockerfile --target lint --build-context component=.
+	docker build . -f Dockerfile --target lint --build-context component=$(COMPONENT)
 endif
 
 .PHONY: fmt
 fmt: ## Run go fmt against code
-ifneq ($(strip $(COMPONENT)),)
 	cd $(COMPONENT) && go fmt ./...
-else
-	go fmt ./...
-endif
 
 .PHONY: vet
 vet: ## Perform static analysis of code
-ifneq ($(strip $(COMPONENT)),)
 	cd $(COMPONENT) && go vet ./...
-else
-	go vet ./...
-endif
 
 .PHONY: test
 test: fmt vet ## Run tests
-ifneq ($(strip $(COMPONENT)),)
 	docker build . -f Dockerfile --target test --build-context component=$(COMPONENT)
-else
-	docker build . -f Dockerfile --target test --build-context component=.
-endif
 
 .PHONY: kbld-image-replace
 kbld-image-replace: ## Add newImage in kbld-config.yaml


### PR DESCRIPTION
# Description
This PR changes the delimiter that is used in COMPONENTS variable to use `.` instead of `?` and also does some refactoring in the Makefile template

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/26

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [x] Breaking change
- [x] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
The delimiter used in COMPONENTS variable has been changed to `.` from `?`
```

# How Has This Been Tested?
Used the sample seed project in the project to build the images and packages.
Ran `make all`

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
