### PR TITLE
add validate-component target to validate COMPONENTS variable

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -23,7 +23,16 @@ $(COMPONENTS):
 ifneq ($(strip $(OCI_REGISTRY)),)
 	$(eval IMAGE = $(OCI_REGISTRY)/$(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
 endif
+	make validate-component COMPONENT_PATH=$(COMPONENT_PATH) IMAGE_NAME=$(IMAGE_NAME) PACKAGE_PATH=$(PACKAGE_PATH)
 	make component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
+
+.PHONY: evaluate-component
+validate-component:
+ifeq ($(strip $(IMAGE_NAME)),)
+	$(error Image name of the component is not set in COMPONENTS variable, check https://github.com/vmware-tanzu/build-tooling-for-integrations/blob/main/docs/build-tooling-getting-started.md#steps-to-use-the-build-tooling for more help)
+else ifeq ($(strip $(PACKAGE_PATH)),)
+	$(error Path to the package of the component is not set in COMPONENTS variable, check https://github.com/vmware-tanzu/build-tooling-for-integrations/blob/main/docs/build-tooling-getting-started.md#steps-to-use-the-build-tooling for more help)
+endif
 
 .PHONY: component-all
 component-all:


### PR DESCRIPTION
Signed-off-by: Harish Yayi <yharish991@gmail.com>

# Description
This PR adds a `validate-component` make target to validate the `COMPONENTS` variable 

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/32

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
```release-note
Added `validate-component` make target to validate the `COMPONENTS` variable
```

# How Has This Been Tested?
Ran `make docker-all` and verified the validation logic of the `validate-component` make target.

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
