### PR TITLE
Update release workflow to not copy makefile to examples

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -35,8 +35,6 @@ jobs:
         run: |
           sed '/^VERSION/s/.*/VERSION ?= v${{ github.event.inputs.version }}/g' templates/Makefile > makefile-version-update
           mv makefile-version-update templates/Makefile
-          cp templates/Makefile examples/multi-module-integration
-          cp templates/Makefile examples/simple-integration
           sed '/^ENV PACKAGE_TOOLS_VERSION/s/.*/ENV PACKAGE_TOOLS_VERSION v${{ github.event.inputs.version }}/g' package-tooling-image/Dockerfile > tmp-dockerfile
           mv tmp-dockerfile package-tooling-image/Dockerfile
       - name: Commit release updates


### PR DESCRIPTION
# Description

The release workflow was attempting to copy `templates/Makefile` to the examples. The Makefile in the examples was sym-linked back to `templates/Makefile`, causing an error.

Fixes #{issue}

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
```

# How Has This Been Tested?
_Describe any testing done to verify changes. Provide enough detail that tests can be reproduced._

# Checklist:
- [ ] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
