### PR TITLE
remove buildx usage in build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Refer to the following table to help decide if Build Tooling is right for you:
 
 ### Prerequisites
 
-1. A development machine with `make`, `docker` and `buildx` with version v0.8 or up installed. If you install Docker 
-   desktop, then it is not explicitly needed to install `buildx` as it is included by default.
+1. A development machine with `make`, `docker` installed.
 2. A project directory for your Tanzu integration code
 
 ### Build & Run

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,41 +1,39 @@
-#syntax=docker/dockerfile:1.4
-
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BUILDER_BASE_IMAGE=golang:1.17
 
 FROM $BUILDER_BASE_IMAGE as base
+ARG COMPONENT
 WORKDIR /workspace
-# Copy the go source
-COPY --from=component . ./
+COPY "$COMPONENT"/go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 # Linting
 FROM golangci/golangci-lint:latest AS lint-base
 FROM base AS lint
-RUN --mount=target=.,from=component \
+RUN --mount=target=. \
     --mount=from=lint-base,src=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/.cache/golangci-lint \
-    golangci-lint run --config /workspace/.golangci.yaml --timeout 10m0s ./...
+    cd $COMPONENT && golangci-lint run --config /workspace/.golangci.yaml --timeout 10m0s ./...
 
 # Testing
 FROM base AS test
-RUN --mount=target=.,from=component \
+RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go test ./...
+    cd $COMPONENT && go test ./...
 
 # Build the manager binary
 FROM base as builder
 ARG LD_FLAGS
 ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
-RUN --mount=target=.,from=component \
+RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /out/manager ./main.go
+    cd $COMPONENT && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /out/manager ./main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -67,7 +67,6 @@ init:
 	docker run --rm -v ${PWD}:/workspace --entrypoint /bin/sh $(BUILD_TOOLING_CONTAINER_IMAGE):$(VERSION) -c "cp Dockerfile /workspace && cp .golangci.yaml /workspace"
 	docker pull $(PACKAGING_CONTAINER_IMAGE):$(VERSION)
 
-
 ##
 ## Other Targets
 ##
@@ -117,7 +116,7 @@ endif
 .PHONY: docker-build
 # Build docker image
 docker-build:
-	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-context component=$(COMPONENT) --load .
+	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
 
 .PHONY: docker-publish
 # Publish docker image
@@ -129,10 +128,10 @@ docker-publish:
 lint:
 ifneq ($(strip $(COMPONENT)),.)
 	cp .golangci.yaml $(COMPONENT)
-	docker build . -f Dockerfile --target lint --build-context component=$(COMPONENT)
+	docker build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
 	rm -rf $(COMPONENT)/.golangci.yaml
 else
-	docker build . -f Dockerfile --target lint --build-context component=$(COMPONENT)
+	docker build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
 endif
 
 .PHONY: fmt
@@ -148,7 +147,7 @@ vet:
 .PHONY: test
 # Run tests
 test: fmt vet
-	docker build . -f Dockerfile --target test --build-context component=$(COMPONENT)
+	docker build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT)
 
 .PHONY: kbld-image-replace
 # Add newImage in kbld-config.yaml

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -64,8 +64,8 @@ install-package-container:
 .PHONY: init
 # Fetch the Dockerfile and pull image needed to build packages
 init:
-	docker run --rm -v ${PWD}:/workspace --entrypoint /bin/sh $(BUILD_TOOLING_CONTAINER_IMAGE):$(VERSION) -c "cp Dockerfile /workspace && cp .golangci.yaml /workspace"
-	docker pull $(PACKAGING_CONTAINER_IMAGE):$(VERSION)
+	$(DOCKER) run --rm -v ${PWD}:/workspace --entrypoint /bin/sh $(BUILD_TOOLING_CONTAINER_IMAGE):$(VERSION) -c "cp Dockerfile /workspace && cp .golangci.yaml /workspace"
+	$(DOCKER) pull $(PACKAGING_CONTAINER_IMAGE):$(VERSION)
 
 ##
 ## Other Targets
@@ -89,8 +89,8 @@ $(COMPONENTS):
 ifneq ($(strip $(OCI_REGISTRY)),)
 	$(eval IMAGE = $(OCI_REGISTRY)/$(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
 endif
-	make validate-component COMPONENT_PATH=$(COMPONENT_PATH) IMAGE_NAME=$(IMAGE_NAME) PACKAGE_PATH=$(PACKAGE_PATH)
-	make component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
+	$(MAKE) validate-component COMPONENT_PATH=$(COMPONENT_PATH) IMAGE_NAME=$(IMAGE_NAME) PACKAGE_PATH=$(PACKAGE_PATH)
+	$(MAKE) component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
 
 .PHONY: evaluate-component
 validate-component:
@@ -107,31 +107,31 @@ ifeq ($(COMPONENT_PATH),)
 else
 	$(eval COMPONENT = $(COMPONENT_PATH))
 endif
-	make COMPONENT=$(COMPONENT) lint
-	make COMPONENT=$(COMPONENT) test
-	make IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
-	make IMAGE=$(IMAGE) docker-publish
-	make KBLD_CONFIG_FILE_PATH=packages/$(PACKAGE_PATH)/kbld-config.yaml DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
+	$(MAKE) COMPONENT=$(COMPONENT) lint
+	$(MAKE) COMPONENT=$(COMPONENT) test
+	$(MAKE) IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
+	$(MAKE) IMAGE=$(IMAGE) docker-publish
+	$(MAKE) KBLD_CONFIG_FILE_PATH=packages/$(PACKAGE_PATH)/kbld-config.yaml DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
 
 .PHONY: docker-build
 # Build docker image
 docker-build:
-	docker build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
+	$(DOCKER) build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
 
 .PHONY: docker-publish
 # Publish docker image
 docker-publish:
-	docker push $(IMAGE)
+	$(DOCKER) push $(IMAGE)
 
 .PHONY: lint
 # Run linting
 lint:
 ifneq ($(strip $(COMPONENT)),.)
 	cp .golangci.yaml $(COMPONENT)
-	docker build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
+	$(DOCKER) build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
 	rm -rf $(COMPONENT)/.golangci.yaml
 else
-	docker build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
+	$(DOCKER) build . -f Dockerfile --target lint --build-arg COMPONENT=$(COMPONENT)
 endif
 
 .PHONY: fmt
@@ -147,12 +147,12 @@ vet:
 .PHONY: test
 # Run tests
 test: fmt vet
-	docker build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT)
+	$(DOCKER) build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT)
 
 .PHONY: kbld-image-replace
 # Add newImage in kbld-config.yaml
 kbld-image-replace:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=kbld_replace \
 	  -e KBLD_CONFIG_FILE_PATH=$(KBLD_CONFIG_FILE_PATH) \
 	  -e DEFAULT_IMAGE=$(DEFAULT_IMAGE) \
@@ -165,7 +165,7 @@ kbld-image-replace:
 .PHONY: package-bundle-generate
 # Generate package bundle for a particular package
 package-bundle-generate:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=package_bundle_generate \
 	  -e PACKAGE_NAME=$(PACKAGE_NAME) \
 	  -e THICK=true \
@@ -179,7 +179,7 @@ package-bundle-generate:
 .PHONY: package-bundle-generate-all
 # Generate package bundle for all packages
 package-bundle-generate-all:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=package_bundle_all_generate \
 	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
 	  -e THICK=true \
@@ -193,7 +193,7 @@ package-bundle-generate-all:
 .PHONY: package-bundle-push
 # Push a particular package bundle
 package-bundle-push:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=package_bundle_push \
 	  -e PACKAGE_NAME=$(PACKAGE_NAME) \
 	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
@@ -209,7 +209,7 @@ package-bundle-push:
 .PHONY: package-bundle-push-all
 # Push all package bundles
 package-bundle-push-all:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=package_bundle_all_push \
 	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
 	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
@@ -225,7 +225,7 @@ package-bundle-push-all:
 .PHONY: repo-bundle-generate
 # Generate repo bundle
 repo-bundle-generate:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=repo_bundle_generate \
 	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
 	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
@@ -239,7 +239,7 @@ repo-bundle-generate:
 .PHONY: repo-bundle-push
 # Push repo bundle
 repo-bundle-push:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=repo_bundle_push \
 	  -e PACKAGE_REPOSITORY=$(PACKAGE_REPOSITORY) \
 	  -e OCI_REGISTRY=$(OCI_REGISTRY) \
@@ -255,7 +255,7 @@ repo-bundle-push:
 .PHONY: package-vendir-sync
 # Performs vendir sync on each package
 package-vendir-sync:
-	@docker run \
+	@$(DOCKER) run \
 	  -e OPERATIONS=vendir_sync \
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -v $(PWD):/workspace \
@@ -264,4 +264,4 @@ package-vendir-sync:
 .PHONY: help
 # Show help
 help:
-	@cat $(MAKEFILE_LIST) | docker run --rm -i xanders/make-help
+	@cat $(MAKEFILE_LIST) | $(DOCKER) run --rm -i xanders/make-help


### PR DESCRIPTION
# Description
This PR removes buildx usage and builds in a native way.

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/40

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [x] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
```

# How Has This Been Tested?
Tested these changes with the examples in the project and it builds successfully

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
