### PR TITLE
generate and copy the binaries back to the host machine

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -3,7 +3,7 @@
 
 ARG BUILDER_BASE_IMAGE=golang:1.17
 
-FROM $BUILDER_BASE_IMAGE as base
+FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE as base
 ARG COMPONENT
 WORKDIR /workspace
 COPY "$COMPONENT"/go.* ./
@@ -29,11 +29,13 @@ RUN --mount=target=. \
 
 # Build the manager binary
 FROM base as builder
+ARG TARGETOS
+ARG TARGETARCH
 ARG LD_FLAGS
 ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
-    cd $COMPONENT && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /out/manager ./main.go
+    cd $COMPONENT && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -o /out/manager ./main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -43,3 +45,17 @@ COPY --from=builder /out/manager .
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]
+
+FROM scratch AS unit-test-coverage
+COPY --from=unit-test /out/cover.out /cover.out
+
+FROM scratch AS bin-unix
+COPY --from=builder /out/manager /
+
+FROM bin-unix AS bin-linux
+FROM bin-unix AS bin-darwin
+
+FROM scratch AS bin-windows
+COPY --from=builder /out/manager /manager.exe
+
+FROM bin-${TARGETOS} as bin

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -20,6 +20,18 @@ RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/golangci-lint \
     cd $COMPONENT && golangci-lint run --config /workspace/.golangci.yaml --timeout 10m0s ./...
 
+FROM base AS fmt
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd $COMPONENT && go fmt ./...
+
+FROM base AS vet
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd $COMPONENT && go vet ./...
+
 # Testing
 FROM base AS test
 RUN --mount=target=. \

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -25,7 +25,7 @@ FROM base AS test
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd $COMPONENT && go test ./...
+    cd $COMPONENT && mkdir /out && go test -v -coverprofile=/out/cover.out ./...
 
 # Build the manager binary
 FROM base as builder
@@ -39,7 +39,7 @@ RUN --mount=target=. \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot as image
 WORKDIR /
 COPY --from=builder /out/manager .
 USER nonroot:nonroot
@@ -47,7 +47,7 @@ USER nonroot:nonroot
 ENTRYPOINT ["/manager"]
 
 FROM scratch AS unit-test-coverage
-COPY --from=unit-test /out/cover.out /cover.out
+COPY --from=test /out/cover.out /cover.out
 
 FROM scratch AS bin-unix
 COPY --from=builder /out/manager /

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -10,6 +10,7 @@ MAKE := make
 
 IMG_DEFAULT_TAG := latest
 IMG_VERSION_OVERRIDE ?= $(IMG_DEFAULT_TAG)
+PLATFORM=local
 COMPONENTS ?= ""."".""
 
 BUILD_TOOLING_CONTAINER_IMAGE ?= ghcr.io/vmware-tanzu/build-tooling
@@ -92,7 +93,7 @@ endif
 	$(MAKE) validate-component COMPONENT_PATH=$(COMPONENT_PATH) IMAGE_NAME=$(IMAGE_NAME) PACKAGE_PATH=$(PACKAGE_PATH)
 	$(MAKE) component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
 
-.PHONY: evaluate-component
+.PHONY: validate-component
 validate-component:
 ifeq ($(strip $(IMAGE_NAME)),)
 	$(error Image name of the component is not set in COMPONENTS variable, check https://github.com/vmware-tanzu/build-tooling-for-integrations/blob/main/docs/build-tooling-getting-started.md#steps-to-use-the-build-tooling for more help)
@@ -112,16 +113,6 @@ endif
 	$(MAKE) IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
 	$(MAKE) IMAGE=$(IMAGE) docker-publish
 	$(MAKE) KBLD_CONFIG_FILE_PATH=packages/$(PACKAGE_PATH)/kbld-config.yaml DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
-
-.PHONY: docker-build
-# Build docker image
-docker-build:
-	$(DOCKER) build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
-
-.PHONY: docker-publish
-# Publish docker image
-docker-publish:
-	$(DOCKER) push $(IMAGE)
 
 .PHONY: lint
 # Run linting
@@ -149,6 +140,21 @@ vet:
 test: fmt vet
 	$(DOCKER) build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT)
 
+.PHONY: docker-build
+# Build docker image
+docker-build:
+	$(DOCKER) build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
+
+.PHONY: docker-publish
+# Publish docker image
+docker-publish:
+	$(DOCKER) push $(IMAGE)
+
+.PHONY: generate-binary
+# Generate binary
+generate-binary:
+	$(DOCKER) build -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --target bin --output bin/$(COMPONENT) --platform ${PLATFORM} --build-context component=$(COMPONENT) .
+
 .PHONY: kbld-image-replace
 # Add newImage in kbld-config.yaml
 kbld-image-replace:
@@ -160,7 +166,6 @@ kbld-image-replace:
 	  -v /var/run/docker.sock:/var/run/docker.sock \
 	  -v $(PWD):/workspace \
 		$(PACKAGING_CONTAINER_IMAGE):$(VERSION)
-
 
 .PHONY: package-bundle-generate
 # Generate package bundle for a particular package

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -141,12 +141,12 @@ endif
 .PHONY: fmt
 # Run go fmt against code
 fmt:
-	cd $(COMPONENT) && go fmt ./...
+	$(DOCKER) build . -f Dockerfile --target fmt --build-arg COMPONENT=$(COMPONENT)
 
 .PHONY: vet
 # Perform static analysis of code
 vet:
-	cd $(COMPONENT) && go vet ./...
+	$(DOCKER) build . -f Dockerfile --target vet --build-arg COMPONENT=$(COMPONENT)
 
 .PHONY: test
 # Run tests

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -74,11 +74,20 @@ init:
 
 .PHONY: all
 # Run linter, tests, build and publish images and packages
-all: docker-all package-vendir-sync package-bundle-generate-all package-bundle-push-all
+all: docker-all package-all
 
 .PHONY: docker-all
 # Run linter, tests, build and publish images
 docker-all: $(COMPONENTS)
+
+.PHONY: build-all
+# Run linter, tests and build binaries
+build-all: BUILD_BIN:=true
+build-all: $(COMPONENTS)
+
+.PHONY: package-all
+# Generate package bundles and push them to a registry
+package-all: package-bundle-generate-all package-bundle-push-all
 
 .PHONY: $(COMPONENTS)
 $(COMPONENTS):
@@ -91,7 +100,7 @@ ifneq ($(strip $(OCI_REGISTRY)),)
 	$(eval IMAGE = $(OCI_REGISTRY)/$(IMAGE_NAME):$(IMG_VERSION_OVERRIDE))
 endif
 	$(MAKE) validate-component COMPONENT_PATH=$(COMPONENT_PATH) IMAGE_NAME=$(IMAGE_NAME) PACKAGE_PATH=$(PACKAGE_PATH)
-	$(MAKE) component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH)
+	$(MAKE) component-all COMPONENT_PATH=$(COMPONENT_PATH) DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) PACKAGE_PATH=$(PACKAGE_PATH) BUILD_BIN=${BUILD_BIN}
 
 .PHONY: validate-component
 validate-component:
@@ -110,9 +119,13 @@ else
 endif
 	$(MAKE) COMPONENT=$(COMPONENT) lint
 	$(MAKE) COMPONENT=$(COMPONENT) test
+ifeq ($(BUILD_BIN), true)
+	$(MAKE) COMPONENT=$(COMPONENT) binary-build
+else
 	$(MAKE) IMAGE=$(IMAGE) COMPONENT=$(COMPONENT) docker-build
 	$(MAKE) IMAGE=$(IMAGE) docker-publish
 	$(MAKE) KBLD_CONFIG_FILE_PATH=packages/$(PACKAGE_PATH)/kbld-config.yaml DEFAULT_IMAGE=$(DEFAULT_IMAGE) IMAGE=$(IMAGE) kbld-image-replace
+endif
 
 .PHONY: lint
 # Run linting

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -139,21 +139,22 @@ vet:
 # Run tests
 test: fmt vet
 	$(DOCKER) build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT)
+	@$(DOCKER) build . -f Dockerfile --target unit-test-coverage --build-arg COMPONENT=$(COMPONENT) --output build/$(COMPONENT)/coverage
 
 .PHONY: docker-build
 # Build docker image
 docker-build:
-	$(DOCKER) build -t $(IMAGE) -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
+	$(DOCKER) build -t $(IMAGE) -f Dockerfile --target image --platform linux/amd64 --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg COMPONENT=$(COMPONENT) .
 
 .PHONY: docker-publish
 # Publish docker image
 docker-publish:
 	$(DOCKER) push $(IMAGE)
 
-.PHONY: generate-binary
-# Generate binary
-generate-binary:
-	$(DOCKER) build -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --target bin --output bin/$(COMPONENT) --platform ${PLATFORM} --build-context component=$(COMPONENT) .
+.PHONY: binary-build
+# Build the binary
+binary-build:
+	$(DOCKER) build -f Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --target bin --output build/$(COMPONENT)/bin --platform ${PLATFORM} --build-arg COMPONENT=$(COMPONENT) .
 
 .PHONY: kbld-image-replace
 # Add newImage in kbld-config.yaml


### PR DESCRIPTION
# Description
This PR adds a make target `binary-build` that generates binaries and copies them back to the host machine and also add `build-all` aggregate make target that runs linter, tests and builds binaries for the go modules in the project

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/42

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
```

# How Has This Been Tested?
Ran the make target `generate-binary` and verified that the binary is created for the go module

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
