### PR TITLE
Make build tooling work for tanzu cli plugins

### DIFF
--- a/docs/build-tooling-getting-started.md
+++ b/docs/build-tooling-getting-started.md
@@ -176,12 +176,15 @@ You should now see plugin binaries in `build/artifacts/plugins`, and plugin pack
 - Before you can publish plugin packages, you need to have built them first. So, complete the [Running Build Tooling for Integrations to Build Tanzu CLI Plugins](#running-build-tooling-for-integrations-to-build-tanzu-cli-plugins) step before doing this step.
 - Select which plugins and which versions of the plugins are to be published by editing [plugin_manifest.yaml file](examples/multi-module-integration/build/artifacts/packages/plugin_manifest.yaml).
 - You need to set a few environment variables: REGISTRY_USERNAME, REGISTRY_PASSWORD, OCI_REGISTRY, PUBLISHER, AND VENDOR.
-- Then, run REGISTRY_USERNAME=<username> REGISTRY_PASSWORD=<password> OCI_REGISTRY=<registry> PUBLISHER=<your organization> VENDOR=<plugin author> make cli-plugin-publish.
+   - Using the GitHub Container Registry as an example, the OCI_REGISTRY is `ghcr.io`.
+   - The VENDOR is your GitHub username.
+   - The PUBLISHER is your GitHub repository name.
+- Run REGISTRY_USERNAME=<username> REGISTRY_PASSWORD=<password> OCI_REGISTRY=<registry> VENDOR=<organization>  PUBLISHER=<project> make cli-plugin-publish.
 
 Here is an example:
 
 ```shell
-REGISTRY_USERNAME=codegold79 REGISTRY_PASSWORD=correcthorsebatterystaple OCI_REGISTRY=ghcr.io PUBLISHER=cgExamples VENDOR=codegold79 make cli-plugin-publish
+REGISTRY_USERNAME=codegold79 REGISTRY_PASSWORD=correcthorsebatterystaple OCI_REGISTRY=ghcr.io VENDOR=codegold79 PUBLISHER=cg-examples make cli-plugin-publish
 ```
 
 You should see the plugin packages uploaded to your OCI_REGISTRY.

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -217,7 +217,7 @@ cli-plugin-publish: cli-plugin-builder-install
 	--build-arg IMGPKG_PASSWORD=$(REGISTRY_PASSWORD) \
 	--build-arg PUBLISHER=$(PUBLISHER) \
 	--build-arg VENDOR=$(VENDOR) \
-	--build-arg COMPONENT=cmd/plugin/plugin-demo-foo
+	--build-arg COMPONENT=cmd/plugin/*
 
 .PHONY: kbld-image-replace
 # Add newImage in kbld-config.yaml


### PR DESCRIPTION
# Description
_Include a summary of the change. If this change fixes an issue, indicate that on the `Fixes` line. Briefly include
relevant context and motivation._

I accidentally left a variable hard-coded in the Docker file for plugin publish. It is now set to a wildcard path.

I also added more information in the documentation as to what PUBLISHER and VENDOR need to be.

Fixes #{issue}

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [x] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Fix bug where CLI plugin name was hard-coded into Makefile plugin publish target.
```

# How Has This Been Tested?
_Describe any testing done to verify changes. Provide enough detail that tests can be reproduced._

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
