### PR TITLE
Fix cache invalidation for unit-test-coverage build stage

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -168,7 +168,7 @@ vet:
 # Run tests
 test: fmt vet
 	$(DOCKER) build . -f Dockerfile --target test --build-arg COMPONENT=$(COMPONENT) --build-arg GOPROXY_ARG=$(GOPROXY)
-	@$(DOCKER) build . -f Dockerfile --target unit-test-coverage --build-arg COMPONENT=$(COMPONENT) --output build/$(COMPONENT)/coverage
+	@$(DOCKER) build . -f Dockerfile --target unit-test-coverage --build-arg COMPONENT=$(COMPONENT) --build-arg GOPROXY_ARG=$(GOPROXY) --output build/$(COMPONENT)/coverage
 
 .PHONY: binary-build
 # Build the binary


### PR DESCRIPTION
# Description
Adds missing argument in unit-test build stage invocation. Ref [PR](https://github.com/vmware-tanzu/tanzu-framework/pull/4462)

Fixes #69 

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [X] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [X] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
  Fixed cache invalidation for unit-test-coverage build stage
```

# How Has This Been Tested?
`make docker-build-all -f build-tooling.mk` on [tanzu-framework](https://github.com/vmware-tanzu/tanzu-framework) repo to ensure cache is not invalidated.

# Checklist:
- [X] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [X] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
