### PR TITLE
bump golang version to 1.19

### DIFF
--- a/examples/multi-module-integration/client-library-module/go.mod
+++ b/examples/multi-module-integration/client-library-module/go.mod
@@ -1,3 +1,3 @@
 module example.com/client-library-module
 
-go 1.18
+go 1.19

--- a/examples/multi-module-integration/cmd/plugin/plugin-demo-bar/go.mod
+++ b/examples/multi-module-integration/cmd/plugin/plugin-demo-bar/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/build-tooling-for-integrations/examples/multi-module-integration/cmd/plugin/plugin-demo-bar
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.6.1

--- a/examples/multi-module-integration/cmd/plugin/plugin-demo-foo/go.mod
+++ b/examples/multi-module-integration/cmd/plugin/plugin-demo-foo/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/build-tooling-for-integrations/examples/multi-module-integration/cmd/plugin/plugin-demo-bar
 
-go 1.18
+go 1.19
 
 require (
 	github.com/spf13/cobra v1.6.1

--- a/examples/multi-module-integration/module1/go.mod
+++ b/examples/multi-module-integration/module1/go.mod
@@ -1,3 +1,3 @@
 module example.com/multi-module-integration/module1
 
-go 1.18
+go 1.19

--- a/examples/multi-module-integration/module2/go.mod
+++ b/examples/multi-module-integration/module2/go.mod
@@ -1,3 +1,3 @@
 module example.com/multi-module-integration/module2
 
-go 1.18
+go 1.19

--- a/examples/simple-integration/go.mod
+++ b/examples/simple-integration/go.mod
@@ -1,3 +1,3 @@
 module example.com/simple-integration
 
-go 1.18
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/build-tooling-for-integrations
 
-go 1.18
+go 1.19
 
 require (
 	github.com/k14s/kbld v0.32.0

--- a/package-tooling-image/Dockerfile
+++ b/package-tooling-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 LABEL org.opencontainers.image.source=https://github.com/vmware-tanzu/build-tooling-for-integrations
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2023 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BUILDER_BASE_IMAGE=golang:1.18
+ARG BUILDER_BASE_IMAGE=golang:1.19
 
 FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE as base
 ARG COMPONENT


### PR DESCRIPTION
# Description
This PR is for bumping the golang version to 1.19 in

- package-tools go module
- package-tooling image
- Dockerfile template
- Examples

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/72

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Bump golang version to 1.18
```

# How Has This Been Tested?
Manually tested the package-tools and examples go modules

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
