### PR TITLE
Add functionality to support running envtests

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BUILDER_BASE_IMAGE=golang:1.19
+ARG ENVTEST_K8S_VERSION=1.26.1
 
 FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE as base
 ARG COMPONENT
@@ -35,11 +36,18 @@ RUN --mount=target=. \
     cd $COMPONENT && go vet ./...
 
 # Testing
+FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE as test-base
+ARG ENVTEST_K8S_VERSION
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+RUN setup-envtest use ${ENVTEST_K8S_VERSION} --bin-dir /bin
+
 FROM base AS test
+ARG ENVTEST_K8S_VERSION
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd $COMPONENT && mkdir /out && go test -v -coverprofile=/out/cover.out ./...
+    --mount=from=test-base,src=/bin/k8s,target=/bin/k8s \
+    cd $COMPONENT && mkdir /out && KUBEBUILDER_ASSETS=/bin/k8s/${ENVTEST_K8S_VERSION}-linux-amd64 go test -v -coverprofile=/out/cover.out ./...
 
 # Build the manager binary
 FROM base as builder


### PR DESCRIPTION
# Description
This PR adds functionality to support running envtests using build tooling. This PR adds a new build stage called `test-base`, this is where all the env test related binaries are downloaded and are later mounted in the `test` stage to run integration tests.

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/74

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Added functionality to support running env tests
```

# How Has This Been Tested?
Tested this functionality to run feature controller [integration tests](https://github.com/vmware-tanzu/tanzu-framework/blob/feature/runtime-core/featuregates/controller/pkg/feature/feature_controller.go)

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
