### PR TITLE
Enable envtests for any platform architecture

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -43,11 +43,12 @@ RUN setup-envtest use ${ENVTEST_K8S_VERSION} --bin-dir /bin
 
 FROM base AS test
 ARG ENVTEST_K8S_VERSION
+ARG BUILDARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=from=test-base,src=/bin/k8s,target=/bin/k8s \
-    cd $COMPONENT && mkdir /out && KUBEBUILDER_ASSETS=/bin/k8s/${ENVTEST_K8S_VERSION}-linux-amd64 go test -v -coverprofile=/out/cover.out ./...
+    cd $COMPONENT && mkdir /out && KUBEBUILDER_ASSETS=/bin/k8s/${ENVTEST_K8S_VERSION}-linux-${BUILDARCH} go test -v -coverprofile=/out/cover.out ./...
 
 # Build the manager binary
 FROM base as builder


### PR DESCRIPTION
# Description
Use docker build [global variables](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope) to determine the platform-specific envtest binaries.

Fixes #87 

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [X] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [X] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Dockerfile supports envtest on all build platforms
```

# How Has This Been Tested?
Verified changes in this [workflow](https://github.com/vmware-tanzu/tanzu-framework/actions/runs/4891122263/jobs/8731242079?pr=4613)

# Checklist:
- [X] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have added test details that prove my fix is effective or that my feature works
