### PR TITLE
Plugin build updates

### DIFF
--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -84,11 +84,13 @@ FROM cli-plugin-builder-install AS cli-plugin-build-prep
 ARG CLI_PLUGIN_VERSION
 ARG CLI_PLUGIN
 ARG OCI_REGISTRY
+ARG CLI_PLUGIN_GO_FLAGS
 RUN --mount=type=bind,readwrite \
     --mount=from=carvel-base,src=/bin/imgpkg,target=/bin/imgpkg \
     tanzu-builder plugin build --match "${CLI_PLUGIN}" \
         --version "${CLI_PLUGIN_VERSION}" \
-        --binary-artifacts "./artifacts/plugins" && \
+        --binary-artifacts "./artifacts/plugins" \
+        --goflags "${CLI_PLUGIN_GO_FLAGS}" && \
     tanzu-builder plugin build-package \
         --oci-registry "${OCI_REGISTRY}" && \
     mkdir -p /out/plugin-artifacts && \

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=target=. \
     cd $COMPONENT && go mod download
 
 # Linting
-FROM golangci/golangci-lint:latest AS lint-base
+FROM golangci/golangci-lint:v1.52.2 AS lint-base
 FROM base AS lint
 RUN --mount=target=. \
     --mount=from=lint-base,src=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -87,7 +87,9 @@ ARG OCI_REGISTRY
 ARG CLI_PLUGIN_GO_FLAGS
 RUN --mount=type=bind,readwrite \
     --mount=from=carvel-base,src=/bin/imgpkg,target=/bin/imgpkg \
-    tanzu-builder plugin build --match "${CLI_PLUGIN}" \
+    tanzu-builder plugin build \
+        --match "${CLI_PLUGIN}" \
+        --os-arch linux_amd64 --os-arch windows_amd64 --os-arch darwin_amd64 \
         --version "${CLI_PLUGIN_VERSION}" \
         --binary-artifacts "./artifacts/plugins" \
         --goflags "${CLI_PLUGIN_GO_FLAGS}" && \

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -211,7 +211,8 @@ cli-plugin-build-%:
 	--build-arg CLI_PLUGIN_VERSION=$(CLI_PLUGIN_VERSION) \
 	--build-arg OCI_REGISTRY=$(REGISTRY_ENDPOINT) \
 	--build-arg CLI_PLUGIN=$* \
-	--build-arg COMPONENT=cmd/plugin/$*
+	--build-arg COMPONENT=cmd/plugin/$* \
+	--build-arg CLI_PLUGIN_GO_FLAGS=$(CLI_PLUGIN_GO_FLAGS)
 
 .PHONY: cli-plugin-publish
 cli-plugin-publish: cli-plugin-builder-install

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -191,12 +191,7 @@ plugin-builder-install:
 	docker build . -f Dockerfile --target cli-plugin-builder-install
 
 .PHONY: cli-plugin-build
-CLI_PLUGIN_TARGETS := $(addprefix cli-plugin-build-, $(shell \
-	if [ -z "$(CLI_PLUGINS)" ]; \
-	then printf "$(shell [ -d "cmd/plugin" ] && cd cmd/plugin && printf "%s" */ | sed 's/\// /g' && cd ../..)";
-	else printf "$(CLI_PLUGINS)"; \
-	fi \
-))
+CLI_PLUGIN_TARGETS := $(addprefix cli-plugin-build-, $(shell if [ -z "$(CLI_PLUGINS)" ]; then printf "$(shell [ -d "cmd/plugin" ] && cd cmd/plugin && printf "%s" */ | sed 's/\// /g' && cd ../..)"; else printf "$(CLI_PLUGINS)"; fi))
 cli-plugin-build: install-registry cli-plugin-builder-install
 	$(MAKE) $(CLI_PLUGIN_TARGETS)
 

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -193,7 +193,7 @@ plugin-builder-install:
 .PHONY: cli-plugin-build
 CLI_PLUGIN_TARGETS := $(addprefix cli-plugin-build-, $(shell \
 	if [ -z "$(CLI_PLUGINS)" ]; \
-	then printf "$(shell [ -d "cmd/plugin" ] && cd cmd/plugin && ls -d * && cd ../..)"; \
+	then printf "$(shell [ -d "cmd/plugin" ] && cd cmd/plugin && printf "%s" */ | sed 's/\// /g' && cd ../..)";
 	else printf "$(CLI_PLUGINS)"; \
 	fi \
 ))


### PR DESCRIPTION
# Description
_Include a summary of the change. If this change fixes an issue, indicate that on the `Fixes` line. Briefly include
relevant context and motivation._

Fixes #90

This PR has commits that do the following:
- Restrict plugin builds to amd64 architectures 
- Find only directories and not other types of files in cmd/plugin
- Pass goflags to Tanzu CLI  plugin builder
- Pass in specific linter version, not latest

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Pass goflags to Tanzu CLI Plugin Builder for plugin builds
```

# How Has This Been Tested?
_Describe any testing done to verify changes. Provide enough detail that tests can be reproduced._

I ran this in my team's downstream pipeline and it is able to successfully build feature and coregen plugins from the Tanzu Framework repo.

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
