### PR TITLE
set the workspace directory in the package tooling image as safe

### DIFF
--- a/package-tooling-image/build-packages.sh
+++ b/package-tooling-image/build-packages.sh
@@ -16,6 +16,8 @@ cd /workspace/${SRC_PATH}
 
 if [ ! -z "${SRC_PATH}" ]; then
   git config --global --add safe.directory /workspace/${SRC_PATH}
+else
+  git config --global --add safe.directory /workspace
 fi
 
 # Install needed Carvel binaries for building packages


### PR DESCRIPTION
# Description
This PR fixes the dubious ownership error that's encountered when we run git commands in the package tooling image with base image golang:1.19

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/94

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
```release-note
Fixed dubious ownership error encountered when running git commands in package tooling image.
```

# How Has This Been Tested?
Tested this on a local machine and also on a dummy pr

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
