### PR TITLE
fix registry image used in package tooling image

### DIFF
--- a/package-tooling-image/build-packages.sh
+++ b/package-tooling-image/build-packages.sh
@@ -6,16 +6,16 @@ if [ ! -z "${REGISTRY_USERNAME:-}" ] && [ ! -z "${REGISTRY_PASSWORD:-}" ] && [ !
    docker login --username "${REGISTRY_USERNAME}" --password "${REGISTRY_PASSWORD}" "${REGISTRY_SERVER}"
 fi
 
-# Setting the OCI_REGISTRY to local registry to support building package bundles and repo bundle in air-gapped scenarios
-if [ ! -z "${OCI_REGISTRY}" ]; then
-  export OCI_REGISTRY="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry):5000"
-fi
-
 # Start a local docker registry
 echo "Stopping and removing any existing local docker registry..."
 docker container stop registry && docker container rm -v registry || true
 echo "Starting local docker registry..."
-docker run -d -p 5001:5000 --name registry registry:2.8
+docker run -d -p 5001:5000 --name registry mirror.gcr.io/library/registry:2.7.1
+
+# Setting the OCI_REGISTRY to local registry to support building package bundles and repo bundle in air-gapped scenarios
+if [ -z "${OCI_REGISTRY:-}" ]; then
+  export OCI_REGISTRY="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry):5000"
+fi
 
 cd /workspace/${SRC_PATH}
 


### PR DESCRIPTION
# Description
This pr updates the registry image being used in package tooling image to be able to pull without rate limits

Fixes https://github.com/vmware-tanzu/build-tooling-for-integrations/issues/98
## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [x] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
```release-note
```

# How Has This Been Tested?
Made sure that I was able to pull the image

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [] New and existing unit tests pass locally with my changes
- [x] I have added test details that prove my fix is effective or that my feature works
