### PR TITLE
Check for existing Tanzu Builder and use if there

### DIFF
--- a/docs/build-tooling-getting-started.md
+++ b/docs/build-tooling-getting-started.md
@@ -143,6 +143,7 @@ Keep an eye out for the long term solution that will not require taking and usin
 - All plugin logic must be in their own directories in `cmd/plugin`. See the plugins in `examples/multi-module-integration/cmd/plugin` as an example.
 - *REQUIRED*: plugin directories must be named after the plugins that they hold. For example, the `cmd/plugin/plugin-demo-bar` is named after the plugin which has the name `plugin-demo-bar`.
 - If you're starting to build your plugin from scratch, copy the `simple-plugin/cm/plugin/plugin-demo-foo` directory and it contents. Update the plugin name, description and logic. Add your own [Cobra](https://github.com/spf13/cobra) commands to your plugin.
+- *OPTIONAL*: We are using the Tanzu CLI Plugin Builder to build and publish plugins. The recommended way of installing the Tanzu Builder is by first installing Tanzu CLI with the help of a package manager. Although it is not recommended, you do have the option of downloading the Tanzu Builder binary and storing it in the build/artifacts/plugin directory, giving the binary the name, `tanzu_builder`. This method is more direct, bypassing the need for Tanzu CLI, but it does not keep track of version, and has high potential of causing errors.
 
 ### Running Build Tooling for Integrations to Build Tanzu CLI Plugins
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -73,9 +73,9 @@ RUN wget -O /bin/imgpkg https://github.com/vmware-tanzu/carvel-imgpkg/releases/d
 FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE AS cli-plugin-builder-install
 ARG TANZU_CLI_VERSION
 RUN --mount=target=. \
-    if [ -e build/artifacts/plugins/tanzu_builder ]; then \
+    if [ -e build/artifacts/plugins/tanzu-cli/tanzu_builder ]; then \
         mkdir -p /root/.local/share/tanzu-cli/builder/ && \
-        cp build/artifacts/plugins/tanzu_builder /root/.local/share/tanzu-cli/builder/ && \
+        cp build/artifacts/plugins/tanzu-cli/tanzu_builder /root/.local/share/tanzu-cli/builder/ && \
         chmod +x /root/.local/share/tanzu-cli/builder/tanzu_builder && \
         ln -s /root/.local/share/tanzu-cli/builder/tanzu_builder /usr/bin/tanzu_builder; \
     else \

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -68,18 +68,27 @@ ARG BUILDARCH
 RUN wget -O /bin/imgpkg https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/${IMGPKG_VERSION}/imgpkg-linux-${BUILDARCH} && \
     chmod +x /bin/imgpkg
 
-# Install Tanzu CLI Plugin Builder.
+# Install Tanzu CLI Plugin Builder via Tanzu CLI or using Tanzu Builder binary, if it is provided.
 # Note: We are temporarily using a deactivated plugin until a bug fix is made to the plugin builder.
 FROM --platform=${BUILDPLATFORM} $BUILDER_BASE_IMAGE AS cli-plugin-builder-install
 ARG TANZU_CLI_VERSION
-RUN apt-get update && \
-    apt-get install -y ca-certificates && \
-    printf "deb https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list && \
-    apt-get update --allow-insecure-repositories && \
-    apt-get install -y tanzu-cli=${TANZU_CLI_VERSION} --allow-unauthenticated && \
-    tanzu ceip set true && \
-    tanzu config eula accept && \
-    TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true tanzu plugin install builder -v v0.90.0-alpha.2
+RUN --mount=target=. \
+    if [ -e build/artifacts/plugins/tanzu_builder ]; then \
+        mkdir -p /root/.local/share/tanzu-cli/builder/ && \
+        cp build/artifacts/plugins/tanzu_builder /root/.local/share/tanzu-cli/builder/ && \
+        chmod +x /root/.local/share/tanzu-cli/builder/tanzu_builder && \
+        ln -s /root/.local/share/tanzu-cli/builder/tanzu_builder /usr/bin/tanzu_builder; \
+    else \
+        apt-get update && \
+        apt-get install -y ca-certificates && \
+        printf "deb https://storage.googleapis.com/tanzu-cli-os-packages/apt tanzu-cli-jessie main" | tee /etc/apt/sources.list.d/tanzu.list && \
+        apt-get update --allow-insecure-repositories && \
+        apt-get install -y tanzu-cli="${TANZU_CLI_VERSION}" --allow-unauthenticated && \
+        tanzu ceip set true && \
+        tanzu config eula accept && \
+        TANZU_CLI_INCLUDE_DEACTIVATED_PLUGINS_TEST_ONLY=true tanzu plugin install builder -v v0.90.0-alpha.2 && \
+        ln -s $(find /root/.local/share/tanzu-cli/builder/ -type f -name "v$TANZU_CLI_VERSION*") /usr/bin/tanzu_builder; \
+    fi
 
 # Run Tanzu plugin builder and compile all plugins in the project's cmd/cli/plugin directory.
 FROM base AS cli-plugin-build-prep
@@ -89,17 +98,14 @@ ARG OCI_REGISTRY
 ARG CLI_PLUGIN_GO_FLAGS
 RUN --mount=type=bind,readwrite \
     --mount=from=carvel-base,src=/bin/imgpkg,target=/bin/imgpkg \
-    --mount=from=cli-plugin-builder-install,src=/usr/bin/tanzu,target=/bin/tanzu \
-    --mount=from=cli-plugin-builder-install,src=/root/.local/share/tanzu-cli/builder,target=/root/.local/share/tanzu-cli/builder \
-    --mount=from=cli-plugin-builder-install,src=/root/.config/tanzu/,target=/root/.config/tanzu/ \
-    --mount=from=cli-plugin-builder-install,src=/root/.cache/tanzu/,target=/root/.cache/tanzu/ \
-    tanzu builder plugin build \
+    --mount=from=cli-plugin-builder-install,src=/usr/bin/tanzu_builder,target=/usr/bin/tanzu_builder \
+    tanzu_builder plugin build \
         --match "${CLI_PLUGIN}" \
         --os-arch linux_amd64 --os-arch windows_amd64 --os-arch darwin_amd64 \
         --version "${CLI_PLUGIN_VERSION}" \
         --binary-artifacts "./artifacts/plugins" \
         --goflags "${CLI_PLUGIN_GO_FLAGS}" && \
-    tanzu builder plugin build-package \
+    tanzu_builder plugin build-package \
         --oci-registry "${OCI_REGISTRY}" && \
     mkdir -p /out/plugin-artifacts && \
     cp -r artifacts /out/plugin-artifacts
@@ -115,11 +121,8 @@ ARG IMGPKG_PASSWORD
 ENV IMGPKG_USERNAME=${IMGPKG_USERNAME} IMGPKG_PASSWORD=${IMGPKG_PASSWORD}
 RUN --mount=type=bind,readwrite \
     --mount=from=carvel-base,src=/bin/imgpkg,target=/bin/imgpkg \
-    --mount=from=cli-plugin-builder-install,src=/usr/bin/tanzu,target=/bin/tanzu \
-    --mount=from=cli-plugin-builder-install,src=/root/.local/share/tanzu-cli/builder,target=/root/.local/share/tanzu-cli/builder \
-    --mount=from=cli-plugin-builder-install,src=/root/.config/tanzu/,target=/root/.config/tanzu/ \
-    --mount=from=cli-plugin-builder-install,src=/root/.cache/tanzu/,target=/root/.cache/tanzu/ \
-    tanzu builder plugin publish-package \
+    --mount=from=cli-plugin-builder-install,src=/usr/bin/tanzu_builder,target=/bin/tanzu_builder \
+    tanzu_builder plugin publish-package \
         --repository "${REPOSITORY}" \
         --publisher "${PUBLISHER}" \
         --vendor "${VENDOR}" \


### PR DESCRIPTION
# Description

Although it's not the recommended way to download and use Tanzu CLI Plugin Builder, provide a direct way to obtain the builder binary and use it. Bypass using Tanzu CLI altogether.

Fixes #108 

## Change Details
Check all that apply:
- [x] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [x] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [x] Requires a documentation change

## Release Note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Allow for existing Tanzu Builder instead of installing it via Tanzu CLI
```

# How Has This Been Tested?
_Describe any testing done to verify changes. Provide enough detail that tests can be reproduced._

I built and published the codegen and featuregate plugins in the Tanzu Framework repository on my local machine.

# Checklist:
- [x] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
