### PR TITLE
Upgrade version of docker and containerd  for package tooling

### DIFF
--- a/package-tooling-image/Dockerfile
+++ b/package-tooling-image/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.19
 
 LABEL org.opencontainers.image.source=https://github.com/vmware-tanzu/build-tooling-for-integrations
 
-ENV DOCKER_CE_VERSION 5:20.10.14~3-0~debian-bullseye
-ENV DOCKER_CE_CLI_VERSION 5:20.10.14~3-0~debian-bullseye
-ENV CONTAINERD_VERSION 1.5.11-1
+ENV DOCKER_CE_VERSION 5:24.0.4-1~debian.12~bookworm
+ENV DOCKER_CE_CLI_VERSION 5:24.0.4-1~debian.12~bookworm
+ENV CONTAINERD_VERSION 1.6.21-1
 ENV PACKAGE_TOOLS_VERSION v0.2.0
 
 RUN apt-get update && \


### PR DESCRIPTION
# Description
build-all target failing to build package-tooling with below error
version '5:20.10.143-0debian-bullseye' for 'docker-ce' was not found

Upgraded the version of docker and containerd

Fixes #111 

## Change Details
Check all that apply:
- [ ] New feature <!-- Adds functionality -->
- [ ] Bug fix <!-- Fixes existing issue -->
- [ ] Non-code change <!-- Changes to documentation or project metadata -->
- [ ] Non-breaking change <!-- no functional changes that break backward compatibility -->
- [ ] Breaking change
- [ ] Requires a documentation change

## Release Note
NA

# How Has This Been Tested?
make build-all

# Checklist:
- [ ] My code follows the [Contribution and Style guidelines](../../CONTRIBUTING.md) of this project
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added test details that prove my fix is effective or that my feature works
